### PR TITLE
Windows-friendly dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ $> npm i
 
 ## Run development mode
 
+In a windows environment:
+```
+$> npm run windev
+```
+
+In other environments:
+
 ```
 $> npm run watch & npm run web-ext:run
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "echo \"no test specified\"",
     "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "windev": "concurrently --kill-others \"npm run watch\" \"npm run web-ext:run\"",
     "eslint": "eslint --fix src/**/*",
     "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
     "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
@@ -21,6 +22,7 @@
     "vuetify": "^1.3.0"
   },
   "devDependencies": {
+    "concurrently": "^4.1.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.14.1",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
fixes #27 

- Installation of the dev dependancy `concurrently` 

- Add a new NPM dev script "windev"